### PR TITLE
modified *.conf files copy location to reflect changes in alsa-card-p…

### DIFF
--- a/install
+++ b/install
@@ -3,7 +3,7 @@
 prefix=$([ "$1" == "" ] && echo "/" || echo "$1")
 
 cp 91-pulseaudio-sennheiser-gsp670.rules ${prefix}etc/udev/rules.d/
-cp sennheiser-gsp670-usb-audio.conf ${prefix}usr/share/pulseaudio/alsa-mixer/profile-sets/
-cp sennheiser-gsp670-output-main.conf ${prefix}usr/share/pulseaudio/alsa-mixer/paths/
-cp sennheiser-gsp670-output-comm.conf ${prefix}usr/share/pulseaudio/alsa-mixer/paths/
-cp sennheiser-gsp670-input-comm.conf ${prefix}usr/share/pulseaudio/alsa-mixer/paths/
+cp sennheiser-gsp670-usb-audio.conf ${prefix}usr/share/alsa-card-profile/mixer/profile-sets/
+cp sennheiser-gsp670-output-main.conf ${prefix}usr/share/alsa-card-profile/mixer/paths/
+cp sennheiser-gsp670-output-comm.conf ${prefix}usr/share/alsa-card-profile/mixer/paths/
+cp sennheiser-gsp670-input-comm.conf ${prefix}usr/share/alsa-card-profile/mixer/paths/


### PR DESCRIPTION
modified *.conf files copy location to reflect changes in alsa-card-profiles package as discussed in
https://wiki.archlinux.org/index.php/Talk:PulseAudio/Examples#Having_both_speakers_and_headphones_plugged_in_and_switching_in_software_on-the-fly